### PR TITLE
Доработана поддержка Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,7 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw clean install -q -Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error
+  - ./mvnw clean install -Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error
 
 after_success:
-  - export KAPPER_TARGET_DIR="$TRAVIS_BUILD_DIR/target"
-  - echo "KAPPER_TARGET_DIR=$KAPPER_TARGET_DIR"
-  - cd $KAPPER_TARGET_DIR; ls -la
-  - export JACOCO_REPORT_DIR="$TRAVIS_BUILD_DIR/target/site/jacoco"
-  - echo "JACOCO_REPORT_DIR=$JACOCO_REPORT_DIR"
-  - cd $JACOCO_REPORT_DIR; ls -la
-  - bash <(curl -s https://codecov.io/bash) -s $JACOCO_REPORT_DIR
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
+  - ./mvnw clean install -Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error
 
 after_success:
   - export KAPPER_TARGET_DIR="$TRAVIS_BUILD_DIR/target"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw clean install -Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error
+  - ./mvnw clean install -q -Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error
 
 after_success:
   - export KAPPER_TARGET_DIR="$TRAVIS_BUILD_DIR/target"

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <argLine></argLine>
     </properties>
 
 <!-- Для централизованного управления зависимостями их версии указываем по возможности только здесь, как и исключения в них -->
@@ -251,13 +250,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>${argLine} ${jaCoCoArgLine}</argLine>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
@@ -276,10 +268,6 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
-<!--                        http://janejieblog.blogspot.com/2017/12/problem-jacoco-skipping-jacoco.html -->
-                        <configuration>
-                            <propertyName>jaCoCoArgLine</propertyName>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>report</id>

--- a/pom.xml
+++ b/pom.xml
@@ -254,10 +254,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkMode>once</forkMode>
-                    <forkCount>1</forkCount>
                     <argLine>${argLine} ${jaCoCoArgLine}</argLine>
-                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
- В файле `pom.xml` убран плагин `maven-surefire-plugin`
- В файле `.travis.yml` убран аргумент `-DargLine`, а аргументы из него теперь передаются отдельно
- В файле `.travis.yml` упрощён вызов https://codecov.io/bash и расширены логи Maven
- Ускорен прогон тестов примерно в 4 раза по сравнению с предыдущими настройками.