### PR TITLE
Актуализация версии Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
+        <version>2.1.6.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -49,11 +49,6 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>1.2.17</version>
-            </dependency>
-            <dependency>
-                <groupId>org.flywaydb</groupId>
-                <artifactId>flyway-core</artifactId>
-                <version>5.0.7</version>
             </dependency>
             <dependency>
                 <groupId>org.dbunit</groupId>

--- a/src/main/java/ru/kappers/model/CurrencyRate.java
+++ b/src/main/java/ru/kappers/model/CurrencyRate.java
@@ -10,6 +10,8 @@ import java.sql.Date;
 @Slf4j
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Table(name = "currency_rate")
 public class CurrencyRate {

--- a/src/main/java/ru/kappers/model/utilmodel/Odds.java
+++ b/src/main/java/ru/kappers/model/utilmodel/Odds.java
@@ -1,7 +1,7 @@
 package ru.kappers.model.utilmodel;
 
 import lombok.Data;
-import lombok.extern.log4j.Log4j;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ru.kappers.model.Fixture;
 
@@ -10,6 +10,7 @@ import java.util.Map;
 //Пока что генерируем случайные коэифценты. В будущем будем парсить с сайта букмекера
 @Data
 @Slf4j
+@NoArgsConstructor
 public class Odds {
     private Fixture fixture;
     private Map<Outcomes, Double> odds;


### PR DESCRIPTION
- Обновлена версия org.springframework.boot:spring-boot-starter-parent до 2.1.6.RELEASE
- Удалено явное задание версии для зависимости org.flywaydb:flyway-core. Теперь версия определяется из spring-boot-starter-parent
- В сущность `ru.kappers.model.utilmodel.Odds` добавлен недостающий конструктор по умолчанию (иначе падают тесты)
- В сущность `ru.kappers.model.CurrencyRate` добавлены конструктор по умолчанию и со всеми полями (иначе падают тесты)