### PR TITLE
Date time API for JPA

### DIFF
--- a/src/main/java/ru/kappers/convert/FixtureRapidDTOToFixtureConverter.java
+++ b/src/main/java/ru/kappers/convert/FixtureRapidDTOToFixtureConverter.java
@@ -23,7 +23,7 @@ public class FixtureRapidDTOToFixtureConverter implements Converter<FixtureRapid
         final Fixture fixture = Fixture.builder()
             .id(dto.getFixture_id())
             .eventTimestamp(dto.getEvent_timestamp())
-            .eventDate(DateTimeUtil.parseTimestampFromZonedDateTime(dto.getEvent_date()))
+            .eventDate(DateTimeUtil.parseLocalDateTimeFromZonedDateTime(dto.getEvent_date()))
             .leagueId(dto.getLeague_id())
             .round(dto.getRound())
             .homeTeamId(dto.getHomeTeam_id())

--- a/src/main/java/ru/kappers/convert/LeagueRapidDTOLeagueConverter.java
+++ b/src/main/java/ru/kappers/convert/LeagueRapidDTOLeagueConverter.java
@@ -23,8 +23,8 @@ public class LeagueRapidDTOLeagueConverter implements Converter<LeagueRapidDTO, 
                 .name(source.getName())
                 .logoUrl(source.getLogo())
                 .season(source.getSeason())
-                .seasonStart(DateTimeUtil.parseTimestampFromDate(source.getSeason_start()+"+03:00"))
-                .seasonEnd(DateTimeUtil.parseTimestampFromDate(source.getSeason_end()+"+03:00"))
+                .seasonStart(DateTimeUtil.parseLocalDateTimeFromStartOfDate(source.getSeason_start()+"+03:00"))
+                .seasonEnd(DateTimeUtil.parseLocalDateTimeFromStartOfDate(source.getSeason_end()+"+03:00"))
                 .build();
     }
 }

--- a/src/main/java/ru/kappers/convert/OddsLeonDTOToOddsLeonConverter.java
+++ b/src/main/java/ru/kappers/convert/OddsLeonDTOToOddsLeonConverter.java
@@ -13,9 +13,11 @@ import ru.kappers.model.leonmodels.*;
 import ru.kappers.service.CompetitorLeonService;
 import ru.kappers.service.LeagueLeonService;
 
-import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 
 @Service
 @Slf4j
@@ -62,10 +64,12 @@ public class OddsLeonDTOToOddsLeonConverter implements Converter<OddsLeonDTO, Od
         return OddsLeon.builder()
                 .id(source.getId())
                 .name(source.getName())
-                .kickoff(new Timestamp(source.getKickoff()))
+                .kickoff(LocalDateTime.ofInstant(Instant.ofEpochMilli(source.getKickoff()),
+                        TimeZone.getDefault().toZoneId()))
                 .open(source.isOpen())
                 .url(source.getUrl())
-                .lastUpdated(new Timestamp(source.getLastUpdated()))
+                .lastUpdated(LocalDateTime.ofInstant(Instant.ofEpochMilli(source.getLastUpdated()),
+                        TimeZone.getDefault().toZoneId()))
                 .league(league)
                 .home(home)
                 .away(away)

--- a/src/main/java/ru/kappers/logic/controller/FixtureController.java
+++ b/src/main/java/ru/kappers/logic/controller/FixtureController.java
@@ -10,8 +10,8 @@ import ru.kappers.model.Fixture;
 import ru.kappers.model.Fixture.Status;
 import ru.kappers.service.FixtureService;
 
-import java.sql.Timestamp;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @RestController
@@ -69,9 +69,9 @@ public class FixtureController {
 
     @RequestMapping(value = "/period", method = RequestMethod.GET)
     public List<Fixture> getFixturesByPeriod(
-            @RequestParam("from") @DateTimeFormat(pattern = "yyyy-MM-dd") Date fromDate,
-            @RequestParam("to") @DateTimeFormat(pattern = "yyyy-MM-dd") Date toDate) {
-        return service.getFixturesByPeriod(new Timestamp(fromDate.getTime()), new Timestamp(toDate.getTime()));
+            @RequestParam("from") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate fromDate,
+            @RequestParam("to") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate toDate) {
+        return service.getFixturesByPeriod(fromDate.atStartOfDay(), toDate.atTime(LocalTime.MAX));
     }
 
 /*

--- a/src/main/java/ru/kappers/logic/controller/UserController.java
+++ b/src/main/java/ru/kappers/logic/controller/UserController.java
@@ -13,10 +13,10 @@ import ru.kappers.model.User;
 import ru.kappers.model.dto.RoleDto;
 import ru.kappers.service.MessageTranslator;
 import ru.kappers.service.UserService;
-import ru.kappers.util.DateTimeUtil;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.Base64;
 
 @Slf4j
@@ -91,7 +91,7 @@ public class UserController {
     @ResponseBody
     public User create(@RequestBody User user) {
         Preconditions.checkNotNull(user, "user is required");
-        user.setDateOfRegistration(DateTimeUtil.getCurrentTime());
+        user.setDateOfRegistration(LocalDateTime.now());
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         return userService.addUser(user);
     }

--- a/src/main/java/ru/kappers/model/Fixture.java
+++ b/src/main/java/ru/kappers/model/Fixture.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -31,7 +31,7 @@ public class Fixture implements Serializable, Comparable {
     @Column(name="event_timestamp")
     private Long eventTimestamp;
     @Column(name="event_date")
-    private Timestamp eventDate;
+    private LocalDateTime eventDate;
     @Column(name="league_id")
     private Integer leagueId;
     @Column(name="round")

--- a/src/main/java/ru/kappers/model/User.java
+++ b/src/main/java/ru/kappers/model/User.java
@@ -10,7 +10,7 @@ import org.joda.money.Money;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,10 +49,10 @@ public class User implements Serializable {
     private String email;
 
     @Column(name = "date_of_birth")
-    private Timestamp dateOfBirth;
+    private LocalDateTime dateOfBirth;
 
     @Column(name = "date_of_registration")
-    private Timestamp dateOfRegistration;
+    private LocalDateTime dateOfRegistration;
 
     @Column(name = "isblocked", nullable = false)
     private boolean isblocked;

--- a/src/main/java/ru/kappers/model/catalog/League.java
+++ b/src/main/java/ru/kappers/model/catalog/League.java
@@ -12,7 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 /**
  * JPA-сущность для лиги
@@ -40,9 +40,9 @@ public class League {
     @Size(max = 9)
     private String season;
     @Column(name="season_start")
-    private Timestamp seasonStart;
+    private LocalDateTime seasonStart;
     @Column(name="season_end")
-    private Timestamp seasonEnd;
+    private LocalDateTime seasonEnd;
     @Column(name="logo")
     @Size(max = 512)
     private String logoUrl;

--- a/src/main/java/ru/kappers/model/leonmodels/OddsLeon.java
+++ b/src/main/java/ru/kappers/model/leonmodels/OddsLeon.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -31,9 +31,9 @@ public class OddsLeon {
     @JoinColumn(name = "away_id")
     private CompetitorLeon away;
     @Column(name = "kickoff")
-    private Timestamp kickoff;
+    private LocalDateTime kickoff;
     @Column(name = "last_updated")
-    private Timestamp lastUpdated;
+    private LocalDateTime lastUpdated;
     @ManyToOne
     @JoinColumn(name = "league_id")
     private LeagueLeon league;

--- a/src/main/java/ru/kappers/repository/FixtureRepository.java
+++ b/src/main/java/ru/kappers/repository/FixtureRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import ru.kappers.model.Fixture;
 import ru.kappers.model.Fixture.Status;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -16,15 +16,15 @@ import java.util.List;
  */
 public interface FixtureRepository extends JpaRepository<Fixture, Integer> {
     @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to")
-    List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to);
+    List<Fixture> getFixturesByPeriod(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 
     @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to")
-    Page<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, Pageable pageable);
+    Page<Fixture> getFixturesByPeriod(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to, Pageable pageable);
 
     @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to and f.status = :filter")
-    List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, @Param("filter") Status filter);
+    List<Fixture> getFixturesByPeriod(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to, @Param("filter") Status filter);
 
     @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to and f.status = :filter")
-    Page<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, @Param("filter") Status filter,
+    Page<Fixture> getFixturesByPeriod(@Param("from") LocalDateTime from, @Param("to") LocalDateTime to, @Param("filter") Status filter,
                                       Pageable pageable);
 }

--- a/src/main/java/ru/kappers/service/FixtureService.java
+++ b/src/main/java/ru/kappers/service/FixtureService.java
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Pageable;
 import ru.kappers.model.Fixture;
 import ru.kappers.model.Fixture.Status;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -19,8 +18,6 @@ public interface FixtureService {
     Fixture updateFixture (Fixture fixture);
     List<Fixture> getAll();
     Page<Fixture> getAll(Pageable pageable);
-    List<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to);
-    Page<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to, Pageable pageable);
     List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to);
     Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Pageable pageable);
     List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter);

--- a/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
@@ -11,7 +11,6 @@ import ru.kappers.model.Fixture.Status;
 import ru.kappers.repository.FixtureRepository;
 import ru.kappers.service.FixtureService;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -72,44 +71,30 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to) {
+    public List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to) {
         log.debug("getFixturesByPeriod(from: {}, to: {})...", from, to);
         return repository.getFixturesByPeriod(from, to);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to, Pageable pageable) {
+    public Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Pageable pageable) {
         log.debug("getFixturesByPeriod(from: {}, to: {}, pageable: {})...", from, to, pageable);
         return repository.getFixturesByPeriod(from, to, pageable);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to) {
-        log.debug("getFixturesByPeriod(from: {}, to: {})...", from, to);
-        return getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to));
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Pageable pageable) {
-        log.debug("getFixturesByPeriod(from: {}, to: {}, pageable: {})...", from, to, pageable);
-        return getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), pageable);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
     public List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter) {
         log.debug("getFixturesByPeriod(from: {}, to: {}, filter: {})...", from, to, filter);
-        return repository.getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), filter);
+        return repository.getFixturesByPeriod(from, to, filter);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter, Pageable pageable) {
         log.debug("getFixturesByPeriod(from: {}, to: {}, filter: {}, pageable: {})...", from, to, filter, pageable);
-        return repository.getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), filter, pageable);
+        return repository.getFixturesByPeriod(from, to, filter, pageable);
     }
 
     protected LocalDateTime getDayBegin(LocalDate date) {

--- a/src/main/java/ru/kappers/service/impl/UserServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/UserServiceImpl.java
@@ -10,9 +10,9 @@ import ru.kappers.exceptions.MoneyTransferException;
 import ru.kappers.model.*;
 import ru.kappers.repository.UsersRepository;
 import ru.kappers.service.*;
-import ru.kappers.util.DateTimeUtil;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -57,7 +57,7 @@ public class UserServiceImpl implements UserService {
             return userByUserName;
         }
         if (user.getDateOfRegistration() == null) {
-            user.setDateOfRegistration(DateTimeUtil.getCurrentTime());
+            user.setDateOfRegistration(LocalDateTime.now());
         }
         if (user.getRole() == null) {
             user.setRole(rolesService.getByName(Role.Names.USER));

--- a/src/main/java/ru/kappers/util/DateTimeUtil.java
+++ b/src/main/java/ru/kappers/util/DateTimeUtil.java
@@ -2,7 +2,6 @@ package ru.kappers.util;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -13,13 +12,6 @@ import java.time.format.DateTimeFormatter;
  */
 @Slf4j
 public final class DateTimeUtil {
-
-	/** миллисекунд в часе */
-	public static final int MILLISECONDS_IN_HOUR = 3600 * 1000;
-	/** миллисекунд в сутках */
-	public static final int MILLISECONDS_IN_DAY = 24 * MILLISECONDS_IN_HOUR;
-	/** миллисекунд в неделе */
-	public static final int MILLISECONDS_IN_WEEK = MILLISECONDS_IN_DAY * 7;
 
 	/**
 	 * Получить экземпляр {@link LocalDateTime} на начало дня из строки
@@ -44,19 +36,6 @@ public final class DateTimeUtil {
 		ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_ZONED_DATE_TIME);
 		final LocalDateTime result = zonedDateTime.toLocalDateTime();
 		log.debug("parseLocalDateTimeFromZonedDateTime(dateTime: {}) return result: {}", dateTime, result);
-		return result;
-	}
-
-	/**
-	 * Получить экземпляр {@link Timestamp} из строки
-	 * @param date строка с датой в формате {@link DateTimeFormatter#ISO_OFFSET_DATE}
-	 * @return экземпляр {@link Timestamp}
-	 */
-	public static Timestamp parseTimestampFromDate(String date) {
-		log.debug("parseTimestampFromDate(date: {})...", date);
-		LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_OFFSET_DATE);
-		final Timestamp result = Timestamp.valueOf(localDate.atStartOfDay());
-		log.debug("parseTimestampFromDate(date: {}) return result: {}", date, result);
 		return result;
 	}
 

--- a/src/main/java/ru/kappers/util/DateTimeUtil.java
+++ b/src/main/java/ru/kappers/util/DateTimeUtil.java
@@ -35,6 +35,19 @@ public final class DateTimeUtil {
 	}
 
 	/**
+	 * Получить экземпляр {@link LocalDateTime} из строки
+	 * @param dateTime строка с датой и временем в формате {@link DateTimeFormatter#ISO_ZONED_DATE_TIME}
+	 * @return экземпляр {@link LocalDateTime}
+	 */
+	public static LocalDateTime parseLocalDateTimeFromZonedDateTime(String dateTime) {
+		log.debug("parseLocalDateTimeFromZonedDateTime(dateTime: {})...", dateTime);
+		ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_ZONED_DATE_TIME);
+		final LocalDateTime result = zonedDateTime.toLocalDateTime();
+		log.debug("parseLocalDateTimeFromZonedDateTime(dateTime: {}) return result: {}", dateTime, result);
+		return result;
+	}
+
+	/**
 	 * Получить экземпляр {@link Timestamp} из строки
 	 * @param date строка с датой в формате {@link DateTimeFormatter#ISO_OFFSET_DATE}
 	 * @return экземпляр {@link Timestamp}
@@ -44,19 +57,6 @@ public final class DateTimeUtil {
 		LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_OFFSET_DATE);
 		final Timestamp result = Timestamp.valueOf(localDate.atStartOfDay());
 		log.debug("parseTimestampFromDate(date: {}) return result: {}", date, result);
-		return result;
-	}
-
-	/**
-	 * Получить экземпляр {@link Timestamp} из строки
-	 * @param dateTime строка с датой и временем в формате {@link DateTimeFormatter#ISO_ZONED_DATE_TIME}
-	 * @return экземпляр {@link Timestamp}
-	 */
-	public static Timestamp parseTimestampFromZonedDateTime(String dateTime) {
-		log.debug("parseTimestampFromZonedDateTime(dateTime: {})...", dateTime);
-		ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_ZONED_DATE_TIME);
-		final Timestamp result = Timestamp.valueOf(zonedDateTime.toLocalDateTime());
-		log.debug("parseTimestampFromZonedDateTime(dateTime: {}) return result: {}", dateTime, result);
 		return result;
 	}
 

--- a/src/main/java/ru/kappers/util/DateTimeUtil.java
+++ b/src/main/java/ru/kappers/util/DateTimeUtil.java
@@ -22,13 +22,15 @@ public final class DateTimeUtil {
 	public static final int MILLISECONDS_IN_WEEK = MILLISECONDS_IN_DAY * 7;
 
 	/**
-	 * Получить экземпляр {@link Timestamp} с текущей датой и временем
-	 * @return экземпляр {@link Timestamp}
+	 * Получить экземпляр {@link LocalDateTime} на начало дня из строки
+	 * @param date строка с датой в формате {@link DateTimeFormatter#ISO_OFFSET_DATE}
+	 * @return экземпляр {@link LocalDateTime}
 	 */
-	public static Timestamp getCurrentTime() {
-		log.debug("getCurrentTime()...");
-		final Timestamp result = Timestamp.valueOf(LocalDateTime.now());
-		log.debug("getCurrentTime() return result: {}", result);
+	public static LocalDateTime parseLocalDateTimeFromStartOfDate(String date) {
+		log.debug("parseLocalDateTimeFromStartOfDate(date: {})...", date);
+		LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_OFFSET_DATE);
+		final LocalDateTime result = localDate.atStartOfDay();
+		log.debug("parseLocalDateTimeFromStartOfDate(date: {}) return result: {}", date, result);
 		return result;
 	}
 

--- a/src/test/java/ru/kappers/convert/FixtureRapidDTOToFixtureConverterTest.java
+++ b/src/test/java/ru/kappers/convert/FixtureRapidDTOToFixtureConverterTest.java
@@ -79,7 +79,7 @@ public class FixtureRapidDTOToFixtureConverterTest {
             assertThat(fixture, is(notNullValue()));
             assertThat(fixture.getId(), is(dto.getFixture_id()));
             assertThat(fixture.getEventTimestamp(), is(dto.getEvent_timestamp()));
-            assertThat(fixture.getEventDate(), is(DateTimeUtil.parseTimestampFromZonedDateTime(dto.getEvent_date())));
+            assertThat(fixture.getEventDate(), is(DateTimeUtil.parseLocalDateTimeFromZonedDateTime(dto.getEvent_date())));
             assertThat(fixture.getLeagueId(), is(dto.getLeague_id()));
             assertThat(fixture.getRound(), is(dto.getRound()));
             assertThat(fixture.getHomeTeamId(), is(dto.getHomeTeam_id()));

--- a/src/test/java/ru/kappers/convert/LeagueRapidDTOLeagueConverterTest.java
+++ b/src/test/java/ru/kappers/convert/LeagueRapidDTOLeagueConverterTest.java
@@ -58,8 +58,8 @@ public class LeagueRapidDTOLeagueConverterTest {
             assertThat(league.getName(), is(dto.getName()));
             assertThat(league.getLogoUrl(), is(dto.getLogo()));
             assertThat(league.getSeason(), is(dto.getSeason()));
-            assertThat(league.getSeasonStart(), is(DateTimeUtil.parseTimestampFromDate(dto.getSeason_start()+"+03:00")));
-            assertThat(league.getSeasonEnd(), is(DateTimeUtil.parseTimestampFromDate(dto.getSeason_end()+"+03:00")));
+            assertThat(league.getSeasonStart(), is(DateTimeUtil.parseLocalDateTimeFromStartOfDate(dto.getSeason_start()+"+03:00")));
+            assertThat(league.getSeasonEnd(), is(DateTimeUtil.parseLocalDateTimeFromStartOfDate(dto.getSeason_end()+"+03:00")));
         }
     }
 }

--- a/src/test/java/ru/kappers/convert/OddsLeonDTOToOddsLeonConverterTest.java
+++ b/src/test/java/ru/kappers/convert/OddsLeonDTOToOddsLeonConverterTest.java
@@ -16,9 +16,11 @@ import ru.kappers.model.leonmodels.OddsLeon;
 import ru.kappers.service.CompetitorLeonService;
 import ru.kappers.service.LeagueLeonService;
 
-import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.TimeZone;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -101,10 +103,12 @@ public class OddsLeonDTOToOddsLeonConverterTest {
             assertThat(result, is(notNullValue()));
             assertThat(result.getId(), is(dto.getId()));
             assertThat(result.getName(), is(dto.getName()));
-            assertThat(result.getKickoff(), is(new Timestamp(dto.getKickoff())));
+            assertThat(result.getKickoff(), is(LocalDateTime.ofInstant(Instant.ofEpochMilli(dto.getKickoff()),
+                    TimeZone.getDefault().toZoneId())));
             assertThat(result.isOpen(), is(dto.isOpen()));
             assertThat(result.getUrl(), is(dto.getUrl()));
-            assertThat(result.getLastUpdated(), is(new Timestamp(dto.getLastUpdated())));
+            assertThat(result.getLastUpdated(), is(LocalDateTime.ofInstant(Instant.ofEpochMilli(dto.getLastUpdated()),
+                    TimeZone.getDefault().toZoneId())));
             assertThat(result.getLeague(), is(league));
             assertThat(result.getHome(), is(competitor1));
             assertThat(result.getAway(), is(competitor2));

--- a/src/test/java/ru/kappers/logic/contract/ContractTest.java
+++ b/src/test/java/ru/kappers/logic/contract/ContractTest.java
@@ -2,18 +2,15 @@ package ru.kappers.logic.contract;
 
 import org.hibernate.Session;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import ru.kappers.model.KapperInfo;
 import ru.kappers.model.User;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.Map;
-
 import static org.junit.Assert.*;
 
+@Ignore("Not implemented yet")
 public class ContractTest {
 
     private static User entity1;

--- a/src/test/java/ru/kappers/logic/controller/UserControllerTest.java
+++ b/src/test/java/ru/kappers/logic/controller/UserControllerTest.java
@@ -19,7 +19,6 @@ import ru.kappers.service.MessageTranslator;
 import ru.kappers.service.UserService;
 
 import java.security.Principal;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.NoSuchElementException;

--- a/src/test/java/ru/kappers/logic/controller/UserControllerTest.java
+++ b/src/test/java/ru/kappers/logic/controller/UserControllerTest.java
@@ -173,8 +173,8 @@ public class UserControllerTest {
         userController = new UserController(userService, encoder, messageTranslator);
         final String testPassword = "testPassword";
         final User user = User.builder()
-                .dateOfBirth(Timestamp.valueOf(LocalDateTime.now().minusYears(20)))
-                .dateOfRegistration(Timestamp.valueOf(LocalDateTime.now().minusMinutes(20)))
+                .dateOfBirth(LocalDateTime.now().minusYears(20))
+                .dateOfRegistration(LocalDateTime.now().minusMinutes(20))
                 .password(testPassword)
                 .build();
         final User userCopy = new User();

--- a/src/test/java/ru/kappers/service/FixtureServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/FixtureServiceImplTest.java
@@ -21,7 +21,6 @@ import ru.kappers.KappersApplication;
 import ru.kappers.model.Fixture;
 import ru.kappers.model.Fixture.ShortStatus;
 import ru.kappers.model.Fixture.Status;
-import ru.kappers.util.DateTimeUtil;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -33,7 +32,6 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.*;
-import static ru.kappers.util.DateTimeUtil.MILLISECONDS_IN_HOUR;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -46,12 +44,11 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private FixtureService service;
 
     private LocalDateTime now = LocalDateTime.now();
-    private Timestamp nowTstmp = Timestamp.valueOf(now);
 
     private Fixture today = Fixture.builder()
             .id(111)
             .eventDate(now)
-            .eventTimestamp(nowTstmp.getTime())
+            .eventTimestamp(Timestamp.valueOf(now).getTime())
             .awayTeam("Real Madrid")
             .homeTeam("FC Barselona")
             .leagueId(87)
@@ -80,7 +77,6 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private Fixture tomorrow = Fixture.builder()
             .id(112)
             .eventDate(now.plusDays(1))
-            .eventTimestamp(nowTstmp.getTime() + DateTimeUtil.MILLISECONDS_IN_DAY)
             .awayTeam("Manchester United")
             .homeTeam("FC Liverpool")
             .leagueId(2)
@@ -91,6 +87,8 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private Fixture tomorrowBegin = new Fixture();
     private Fixture tomorrowEnd = new Fixture();
     {
+        tomorrow.setEventTimestamp(Timestamp.valueOf(tomorrow.getEventDate()).getTime());
+
         Fixture it = tomorrowBegin;
         BeanUtils.copyProperties(tomorrow, it);
         it.setId(it.getId() + 10);
@@ -107,7 +105,6 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private Fixture yesterday = Fixture.builder()
             .id(110)
             .eventDate(now.minusDays(1))
-            .eventTimestamp(nowTstmp.getTime() - DateTimeUtil.MILLISECONDS_IN_DAY)
             .awayTeam("Paris Saint Germain")
             .homeTeam("Lyon")
             .leagueId(4)
@@ -118,6 +115,8 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private Fixture yesterdayBegin = new Fixture();
     private Fixture yesterdayEnd = new Fixture();
     {
+        yesterday.setEventTimestamp(Timestamp.valueOf(yesterday.getEventDate()).getTime());
+
         Fixture it = yesterdayBegin;
         BeanUtils.copyProperties(yesterday, it);
         it.setId(it.getId() + 10);
@@ -134,7 +133,6 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private Fixture nextWeek = Fixture.builder()
             .id(113)
             .eventDate(now.plusDays(7))
-            .eventTimestamp(nowTstmp.getTime() + DateTimeUtil.MILLISECONDS_IN_WEEK)
             .awayTeam("Real Madrid")
             .homeTeam("FC Barselona")
             .leagueId(87)
@@ -145,13 +143,18 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     private Fixture lastWeek = Fixture.builder()
             .id(114)
             .eventDate(now.minusDays(7))
-            .eventTimestamp(nowTstmp.getTime() - DateTimeUtil.MILLISECONDS_IN_WEEK)
             .awayTeam("Paris Saint Germain")
             .homeTeam("Lyon")
             .leagueId(4)
             .status(Status.MATCH_FINISHED)
             .statusShort(ShortStatus.MATCH_FINISHED)
             .build();
+
+    {
+        nextWeek.setEventTimestamp(Timestamp.valueOf(nextWeek.getEventDate()).getTime());
+
+        lastWeek.setEventTimestamp(Timestamp.valueOf(lastWeek.getEventDate()).getTime());
+    }
 
     protected void clearTable() {
         deleteFromTables("fixtures");

--- a/src/test/java/ru/kappers/service/FixtureServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/FixtureServiceImplTest.java
@@ -50,7 +50,7 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
 
     private Fixture today = Fixture.builder()
             .id(111)
-            .eventDate(nowTstmp)
+            .eventDate(now)
             .eventTimestamp(nowTstmp.getTime())
             .awayTeam("Real Madrid")
             .homeTeam("FC Barselona")
@@ -65,21 +65,21 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
         Fixture it = todayBegin;
         BeanUtils.copyProperties(today, it);
         it.setId(it.getId() + 10);
-        it.setEventDate(Timestamp.valueOf(LocalDateTime.of(now.toLocalDate(), LocalTime.MIN)));
-        it.setEventTimestamp(it.getEventDate().getTime());
+        it.setEventDate(LocalDateTime.of(now.toLocalDate(), LocalTime.MIN));
+        it.setEventTimestamp(Timestamp.valueOf(it.getEventDate()).getTime());
         it.setStatus(Status.MATCH_FINISHED);
         it.setStatusShort(ShortStatus.MATCH_FINISHED);
 
         it = todayEnd;
         BeanUtils.copyProperties(today, it);
         it.setId(it.getId() + 11);
-        it.setEventDate(Timestamp.valueOf(LocalDateTime.of(now.toLocalDate(), LocalTime.MAX)));
-        it.setEventTimestamp(it.getEventDate().getTime());
+        it.setEventDate(LocalDateTime.of(now.toLocalDate(), LocalTime.MAX));
+        it.setEventTimestamp(Timestamp.valueOf(it.getEventDate()).getTime());
     }
 
     private Fixture tomorrow = Fixture.builder()
             .id(112)
-            .eventDate(new Timestamp(nowTstmp.getTime() + DateTimeUtil.MILLISECONDS_IN_DAY))
+            .eventDate(now.plusDays(1))
             .eventTimestamp(nowTstmp.getTime() + DateTimeUtil.MILLISECONDS_IN_DAY)
             .awayTeam("Manchester United")
             .homeTeam("FC Liverpool")
@@ -94,19 +94,19 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
         Fixture it = tomorrowBegin;
         BeanUtils.copyProperties(tomorrow, it);
         it.setId(it.getId() + 10);
-        it.setEventDate(Timestamp.valueOf(LocalDateTime.of(now.plusDays(1).toLocalDate(), LocalTime.MIN)));
-        it.setEventTimestamp(it.getEventDate().getTime());
+        it.setEventDate(LocalDateTime.of(now.plusDays(1).toLocalDate(), LocalTime.MIN));
+        it.setEventTimestamp(Timestamp.valueOf(it.getEventDate()).getTime());
 
         it = tomorrowEnd;
         BeanUtils.copyProperties(tomorrow, it);
         it.setId(it.getId() + 11);
-        it.setEventDate(Timestamp.valueOf(LocalDateTime.of(now.plusDays(1).toLocalDate(), LocalTime.MAX)));
-        it.setEventTimestamp(it.getEventDate().getTime());
+        it.setEventDate(LocalDateTime.of(now.plusDays(1).toLocalDate(), LocalTime.MAX));
+        it.setEventTimestamp(Timestamp.valueOf(it.getEventDate()).getTime());
     }
 
     private Fixture yesterday = Fixture.builder()
             .id(110)
-            .eventDate(new Timestamp(nowTstmp.getTime() - DateTimeUtil.MILLISECONDS_IN_DAY))
+            .eventDate(now.minusDays(1))
             .eventTimestamp(nowTstmp.getTime() - DateTimeUtil.MILLISECONDS_IN_DAY)
             .awayTeam("Paris Saint Germain")
             .homeTeam("Lyon")
@@ -121,19 +121,19 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
         Fixture it = yesterdayBegin;
         BeanUtils.copyProperties(yesterday, it);
         it.setId(it.getId() + 10);
-        it.setEventDate(Timestamp.valueOf(LocalDateTime.of(now.minusDays(1).toLocalDate(), LocalTime.MIN)));
-        it.setEventTimestamp(it.getEventDate().getTime());
+        it.setEventDate(LocalDateTime.of(now.minusDays(1).toLocalDate(), LocalTime.MIN));
+        it.setEventTimestamp(Timestamp.valueOf(it.getEventDate()).getTime());
 
         it = yesterdayEnd;
         BeanUtils.copyProperties(yesterday, it);
         it.setId(it.getId() + 11);
-        it.setEventDate(Timestamp.valueOf(LocalDateTime.of(now.minusDays(1).toLocalDate(), LocalTime.MAX)));
-        it.setEventTimestamp(it.getEventDate().getTime());
+        it.setEventDate(LocalDateTime.of(now.minusDays(1).toLocalDate(), LocalTime.MAX));
+        it.setEventTimestamp(Timestamp.valueOf(it.getEventDate()).getTime());
     }
 
     private Fixture nextWeek = Fixture.builder()
             .id(113)
-            .eventDate(new Timestamp(nowTstmp.getTime() + DateTimeUtil.MILLISECONDS_IN_WEEK))
+            .eventDate(now.plusDays(7))
             .eventTimestamp(nowTstmp.getTime() + DateTimeUtil.MILLISECONDS_IN_WEEK)
             .awayTeam("Real Madrid")
             .homeTeam("FC Barselona")
@@ -144,7 +144,7 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
 
     private Fixture lastWeek = Fixture.builder()
             .id(114)
-            .eventDate(new Timestamp(nowTstmp.getTime() - DateTimeUtil.MILLISECONDS_IN_WEEK))
+            .eventDate(now.minusDays(7))
             .eventTimestamp(nowTstmp.getTime() - DateTimeUtil.MILLISECONDS_IN_WEEK)
             .awayTeam("Paris Saint Germain")
             .homeTeam("Lyon")
@@ -168,7 +168,7 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
     public void getById() {
         Fixture fixture = Fixture.builder()
                 .id(54552)
-                .eventDate(Timestamp.valueOf(LocalDateTime.now()))
+                .eventDate(LocalDateTime.now())
                 .build();
         service.addRecord(fixture);
         Fixture byId = service.getById(54552);
@@ -248,8 +248,7 @@ public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringCon
         clearTable();
         Stream.of(today, tomorrow, yesterday).forEach(service::addRecord);
 
-        final List<Fixture> todaysFixtures = service.getFixturesByPeriod(new Timestamp(nowTstmp.getTime() - 8 * MILLISECONDS_IN_HOUR),
-                new Timestamp(nowTstmp.getTime() + 8 * MILLISECONDS_IN_HOUR));
+        final List<Fixture> todaysFixtures = service.getFixturesByPeriod(now.minusHours(8), now.plusHours(8));
 
         assertTrue(todaysFixtures.contains(today));
         Stream.of(tomorrow, yesterday).forEach(it -> assertFalse(todaysFixtures.contains(it)));

--- a/src/test/java/ru/kappers/service/KapperInfoServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/KapperInfoServiceImplTest.java
@@ -22,6 +22,9 @@ import ru.kappers.model.User;
 import ru.kappers.util.DateTimeUtil;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import static org.junit.Assert.*;
 
@@ -37,7 +40,8 @@ public class KapperInfoServiceImplTest extends AbstractTransactionalJUnit4Spring
             .userName("user1")
             .name("юзер")
             .password("assaasas")
-            .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
+            .dateOfBirth(DateTimeUtil.parseLocalDateTimeFromStartOfDate("1965-08-06+03:00"))
+            .dateOfRegistration(LocalDateTime.of(LocalDate.parse("2019-01-20"), LocalTime.MIDNIGHT))
             .lang("RUSSIAN")
             .balance(Money.of(CurrencyUnit.EUR, new BigDecimal("10.00")))
             .build();
@@ -45,7 +49,8 @@ public class KapperInfoServiceImplTest extends AbstractTransactionalJUnit4Spring
             .userName("kapper1")
             .name("каппер")
             .password("assaasas")
-            .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
+            .dateOfBirth(DateTimeUtil.parseLocalDateTimeFromStartOfDate("1965-08-06+03:00"))
+            .dateOfRegistration(LocalDateTime.of(LocalDate.parse("2019-01-20"), LocalTime.MIDNIGHT))
             .lang("RUSSIAN")
             .balance(Money.of(CurrencyUnit.USD, new BigDecimal("100.00")))
             .build();

--- a/src/test/java/ru/kappers/service/UserServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/UserServiceImplTest.java
@@ -24,6 +24,9 @@ import ru.kappers.repository.UsersRepository;
 import ru.kappers.util.DateTimeUtil;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -49,7 +52,8 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
             .userName("admin")
             .name("админ")
             .password("asasdgfas")
-            .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
+            .dateOfBirth(DateTimeUtil.parseLocalDateTimeFromStartOfDate("1965-08-06+03:00"))
+            .dateOfRegistration(LocalDateTime.of(LocalDate.parse("2019-01-20"), LocalTime.MIDNIGHT))
             .lang("RUSSIAN")
             .balance(Money.of(CurrencyUnit.EUR, new BigDecimal("10.00")))
             .build();
@@ -57,7 +61,8 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
             .userName("user")
             .name("юзер")
             .password("assaasas")
-            .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
+            .dateOfBirth(DateTimeUtil.parseLocalDateTimeFromStartOfDate("1965-08-06+03:00"))
+            .dateOfRegistration(LocalDateTime.of(LocalDate.parse("2019-01-22"), LocalTime.MIDNIGHT))
             .lang("RUSSIAN")
             .balance(Money.of(CurrencyUnit.USD, new BigDecimal("10.00")))
             .build();
@@ -65,7 +70,8 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
             .userName("kapper")
             .name("каппер")
             .password("assaasas")
-            .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
+            .dateOfBirth(DateTimeUtil.parseLocalDateTimeFromStartOfDate("1965-08-06+03:00"))
+            .dateOfRegistration(LocalDateTime.of(LocalDate.parse("2019-01-21"), LocalTime.MIDNIGHT))
             .lang("RUSSIAN")
             .balance(Money.of(CurrencyUnit.of("RUB"), new BigDecimal("100.00")))
             .build();

--- a/src/test/java/ru/kappers/util/DateTimeUtilTest.java
+++ b/src/test/java/ru/kappers/util/DateTimeUtilTest.java
@@ -2,26 +2,27 @@ package ru.kappers.util;
 
 import org.junit.Test;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
 public class DateTimeUtilTest {
 
 	@Test
-	public void getCurrentTime() throws Exception {
-		final Timestamp currentTime = DateTimeUtil.getCurrentTime();
-		assertNotNull(currentTime);
+	public void parseLocalDateTimeFromStartOfDate() {
+		LocalDateTime parsed = DateTimeUtil.parseLocalDateTimeFromStartOfDate("2000-12-02+02:00");
+		LocalDateTime expected = LocalDateTime.of(2000, Month.DECEMBER, 2, 00, 0, 0);
+		assertEquals(expected, parsed);
+	}
 
-		TimeUnit.MILLISECONDS.sleep(5);
-		assertTrue(currentTime.before(DateTimeUtil.getCurrentTime()));
+	@Test(expected = RuntimeException.class)
+	public void parseLocalDateTimeFromStartOfDateWithWrongFormat(){
+		DateTimeUtil.parseLocalDateTimeFromStartOfDate("98798asdt");
 	}
 
 	@Test

--- a/src/test/java/ru/kappers/util/DateTimeUtilTest.java
+++ b/src/test/java/ru/kappers/util/DateTimeUtilTest.java
@@ -2,7 +2,6 @@ package ru.kappers.util;
 
 import org.junit.Test;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.ZoneId;
@@ -41,15 +40,4 @@ public class DateTimeUtilTest {
 		DateTimeUtil.parseLocalDateTimeFromZonedDateTime("20011202T10:15:30+01:00");
 	}
 
-	@Test
-	public void parseTimestampFromDate(){
-		Timestamp parsed = DateTimeUtil.parseTimestampFromDate("2000-12-02+02:00");
-		Timestamp expected = Timestamp.valueOf(LocalDateTime.of(2000, Month.DECEMBER, 2, 00, 0, 0));
-		assertEquals(expected, parsed);
-	}
-
-	@Test(expected = RuntimeException.class)
-	public void parseTimestampFromDateWithWrongFormat(){
-		DateTimeUtil.parseTimestampFromDate("98798asd");
-	}
 }

--- a/src/test/java/ru/kappers/util/DateTimeUtilTest.java
+++ b/src/test/java/ru/kappers/util/DateTimeUtilTest.java
@@ -26,6 +26,22 @@ public class DateTimeUtilTest {
 	}
 
 	@Test
+	public void parseLocalDateTimeFromZonedDateTime() {
+		final ZonedDateTime expectedZonedDateTime = ZonedDateTime.of(
+				LocalDateTime.of(2001, Month.DECEMBER, 2, 10, 15, 30),
+				ZoneId.of("+01:00"));
+		LocalDateTime expected = expectedZonedDateTime.toLocalDateTime();
+		LocalDateTime parsed = DateTimeUtil.parseLocalDateTimeFromZonedDateTime("2001-12-02T10:15:30+01:00");
+
+		assertEquals(expected, parsed);
+	}
+
+	@Test(expected = DateTimeParseException.class)
+	public void parseLocalDateTimeFromZonedDateTimeWithWrongFormat() {
+		DateTimeUtil.parseLocalDateTimeFromZonedDateTime("20011202T10:15:30+01:00");
+	}
+
+	@Test
 	public void parseTimestampFromDate(){
 		Timestamp parsed = DateTimeUtil.parseTimestampFromDate("2000-12-02+02:00");
 		Timestamp expected = Timestamp.valueOf(LocalDateTime.of(2000, Month.DECEMBER, 2, 00, 0, 0));
@@ -35,21 +51,5 @@ public class DateTimeUtilTest {
 	@Test(expected = RuntimeException.class)
 	public void parseTimestampFromDateWithWrongFormat(){
 		DateTimeUtil.parseTimestampFromDate("98798asd");
-	}
-
-	@Test
-	public void parseTimestampFromZonedDateTime(){
-		final ZonedDateTime expectedZonedDateTime = ZonedDateTime.of(
-				LocalDateTime.of(2001, Month.DECEMBER, 2, 10, 15, 30),
-				ZoneId.of("+01:00"));
-		Timestamp expectedTimestamp = Timestamp.valueOf(expectedZonedDateTime.toLocalDateTime());
-		Timestamp parsedTimestamp = DateTimeUtil.parseTimestampFromZonedDateTime("2001-12-02T10:15:30+01:00");
-
-		assertEquals(expectedTimestamp, parsedTimestamp);
-	}
-
-	@Test(expected = DateTimeParseException.class)
-	public void parseTimestampFromZonedDateTimeWithWrongFormat() {
-		DateTimeUtil.parseTimestampFromZonedDateTime("20011202T10:15:30+01:00");
 	}
 }


### PR DESCRIPTION
- Доработка хранения даты-времени в `User`
  - Теперь в `User` дата-время хранится в `java.time.LocalDateTime`
  - Доработаны сервис, контроллер
  - В утилитном классе `DateTimeUtil` удален метод `getCurrentTime()` и добавлен `parseLocalDateTimeFromStartOfDate()`
  - Доработаны интеграционные и unit-тесты
- Отключены нереализованные unit-тесты `ContractTest`
- Доработка хранения даты-времени в `Fixture`
  - Теперь в `Fixture` дата-время хранится в `java.time.LocalDateTime`
  - Доработаны репозиторий, сервис, контроллер, конвертер
  - В утилитном классе `DateTimeUtil` удален метод `parseTimestampFromZonedDateTime()` и добавлен `parseLocalDateTimeFromZonedDateTime()`
  - Доработаны интеграционные и unit-тесты
- Доработка хранения даты-времени в `OddsLeon`
  - Теперь в `OddsLeon` дата-время хранится в `java.time.LocalDateTime`
  - Доработан конвертер
  - Доработаны unit-тесты
- Доработка хранения даты-времени в `League`
  - Теперь в `League` дата-время хранится в `java.time.LocalDateTime`
  - Доработан конвертер
  - Из класса `DateTimeUtil` удален метод `parseTimestampFromDate()` и лишние константы
  - Доработаны unit-тесты